### PR TITLE
This commit introduces the necessary configuration to build and deplo…

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       contents: write
       actions: read
 
-    if: github.repository == 'google-a2a/A2A'
+    if: github.repository == 'jeongsk/A2A'
 
     steps:
       - name: Checkout Code
@@ -87,7 +87,7 @@ jobs:
     permissions:
       contents: write
       actions: read
-    if: github.repository == 'google-a2a/A2A' && github.event_name == 'push' && github.ref == 'refs/heads/main' # Only run on push to main for now
+    if: github.repository == 'jeongsk/A2A' && github.event_name == 'push' && github.ref == 'refs/heads/main' # Only run on push to main for now
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,9 @@ on:
       - ".github/workflows/docs.yml"
       - "requirements-docs.txt"
       - "mkdocs.yml"
+      - "mkdocs-ko.yml" # Added for Korean docs
       - "docs/**"
+      - "docs-ko/**" # Added for Korean docs
   pull_request:
     branches:
       - main
@@ -16,7 +18,9 @@ on:
       - ".github/workflows/docs.yml"
       - "requirements-docs.txt"
       - "mkdocs.yml"
+      - "mkdocs-ko.yml" # Added for Korean docs
       - "docs/**"
+      - "docs-ko/**" # Added for Korean docs
   release:
     types:
       - published
@@ -77,3 +81,36 @@ jobs:
 
           echo "Setting 'latest' as the default version for the site..."
           mike set-default --push latest
+
+  build_and_deploy_ko:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    if: github.repository == 'google-a2a/A2A' && github.event_name == 'push' && github.ref == 'refs/heads/main' # Only run on push to main for now
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Need full history for gh-deploy
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13 # Match existing job
+      - name: Restore pip cache
+        uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-docs.txt') }} # Can reuse cache key
+          path: ~/.cache/pip
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install documentation dependencies
+        run: pip install -r requirements-docs.txt
+      - name: Build Korean Documentation
+        run: mkdocs build --config-file mkdocs-ko.yml
+      - name: Deploy Korean Documentation
+        run: mkdocs gh-deploy --config-file mkdocs-ko.yml --force # Use --force to avoid issues with mike's versioning files if any linger or if deploying to a clean path

--- a/mkdocs-ko.yml
+++ b/mkdocs-ko.yml
@@ -1,6 +1,6 @@
 # Project information
 site_name: Agent2Agent (A2A) 프로토콜 (한국어)
-site_url: https://google-a2a.github.io/A2A/ko/
+site_url: https://jeongsk.github.io/A2A/ko/
 site_description: >-
   에이전트 애플리케이션 간의 통신과 상호 운용성을 가능하게 하는 개방형 프로토콜입니다.
 site_dir: site/ko

--- a/mkdocs-ko.yml
+++ b/mkdocs-ko.yml
@@ -1,0 +1,163 @@
+# Project information
+site_name: Agent2Agent (A2A) 프로토콜 (한국어)
+site_url: https://google-a2a.github.io/A2A/ko/
+site_description: >-
+  에이전트 애플리케이션 간의 통신과 상호 운용성을 가능하게 하는 개방형 프로토콜입니다.
+site_dir: site/ko
+docs_dir: docs-ko
+
+extra:
+  a2a_version: !ENV [MIKE_VERSION, 'local-dev']
+
+# Navigation
+nav:
+  - Home: index.md
+  - Topics:
+    - What is A2A?: topics/what-is-a2a.md
+    - Key Concepts: topics/key-concepts.md
+    - A2A and MCP: topics/a2a-and-mcp.md
+    - Agent Discovery: topics/agent-discovery.md
+    - Enterprise-Ready Features: topics/enterprise-ready.md
+    - Streaming & Asynchronous Operations: topics/streaming-and-async.md
+    - Extensions: topics/extensions.md
+  - Specification: specification.md
+  - Community: community.md
+  - Partners: partners.md
+  - SDK Reference:
+    - Python: sdk/python/index.md
+  - Tutorial (Python):
+    - Introduction: tutorials/python/1-introduction.md
+    - Setup: tutorials/python/2-setup.md
+    - Agent Skills & Agent Card: tutorials/python/3-agent-skills-and-card.md
+    - Agent Executor: tutorials/python/4-agent-executor.md
+    - Start Server: tutorials/python/5-start-server.md
+    - Interact with Server: tutorials/python/6-interact-with-server.md
+    - Streaming & Multiturn: tutorials/python/7-streaming-and-multiturn.md
+    - Next Steps: tutorials/python/8-next-steps.md
+
+# Repository
+repo_name: google-a2a/A2A
+repo_url: https://github.com/google-a2a/A2A
+
+# Copyright
+copyright: Copyright Google 2025
+
+# Custom CSS
+extra_css:
+  - stylesheets/custom.css
+
+# Configuration
+theme:
+  name: material
+  font:
+    text: Google Sans
+    code: Roboto Mono
+  logo: assets/a2a-logo-white.svg
+  favicon: assets/a2a-logo-black.svg
+  icon:
+    repo: fontawesome/brands/github
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: white
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: white
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - content.code.annotate
+    - content.code.copy
+    - content.code.select
+    - content.tabs.link
+    - navigation.expand
+    - navigation.footer
+    - navigation.indexes
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.path
+    - navigation.tabs
+    - navigation.top
+    - navigation.tracking
+    - toc.follow
+    # - versioning:
+    #     provider: mike
+
+# Extensions
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets:
+      url_download: true
+      dedent_subsections: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
+  - toc:
+      permalink: true
+
+# Plugins
+plugins:
+  - search
+  - macros
+  - redirects:
+      redirect_maps:
+        "spec-json.md": https://raw.githubusercontent.com/google-a2a/A2A/refs/heads/main/specification/json/a2a.json
+        "specification/overview.md": "specification.md"
+        "specification/agent-card.md": "specification.md#5-agent-discovery-the-agent-card"
+        "specification/agent-to-agent-communication.md": "specification.md#6-protocol-data-objects"
+        "specification/sample-messages.md": "specification.md#9-common-workflows-examples"
+        "specification/details.md": "specification.md"
+        "documentation.md": "topics/key-concepts.md"
+        "resources.md": "index.md"
+        "topics/push-notifications.md": "topics/streaming-and-async.md"
+        "specification/topics/a2a_and_mcp.md": "topics/a2a-and-mcp.md"
+        "specification/topics/agent_discovery.md": "topics/agent-discovery.md"
+        "specification/topics/enterprise_ready.md": "topics/enterprise-ready.md"
+        "specification/topics/push_notification.md": "topics/streaming-and-async.md"
+        "specification/topics/push_notifications.md": "topics/streaming-and-async.md"
+        "topics/index.md": "topics/what-is-a2a.md"
+        # Tutorial
+        "tutorials/index.md": "tutorials/python/1-introduction.md"
+        "tutorials/python/index.md": "tutorials/python/1-introduction.md"
+        "tutorials/python/1_introduction.md": "tutorials/python/1-introduction.md"
+        "tutorials/python/3-create-project.md": "tutorials/python/2-setup.md"
+        "tutorials/python/4-agent-skills.md": "tutorials/python/3-agent-skills-and-card.md"
+        "tutorials/python/5-add-agent-card.md": "tutorials/python/3-agent-skills-and-card.md"
+        "tutorials/python/6-start-server.md": "tutorials/python/5-start-server.md"
+        "tutorials/python/7-interact-with-server.md": "tutorials/python/6-interact-with-server.md"
+        "tutorials/python/8-agent-capabilities.md": "tutorials/python/7-streaming-and-multiturn.md"
+        "tutorials/python/9-ollama-agent.md": "tutorials/python/7-streaming-and-multiturn.md"
+        "tutorials/python/10-next-steps.md": "tutorials/python/8-next-steps.md"
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            show_root_heading: false
+            show_object_full_path: false
+            show_if_no_docstring: true
+            filters: ["!^_"]
+            extra:
+              show_value: true
+              show_qualifiers: false


### PR DESCRIPTION
…y the Korean version of your documentation.

Key changes:
- Added `mkdocs-ko.yml`: A new MkDocs configuration file tailored for the Korean documentation (`docs-ko` directory). It specifies 'docs-ko' as the content source, sets the site URL to end with '/ko/', and disables 'mike' versioning for this language version initially. The build output is directed to `site/ko`.
- Updated `.github/workflows/docs.yml`:
    - Added a new job `build_and_deploy_ko`.
    - This job builds the Korean documentation using `mkdocs-ko.yml`.
    - It deploys the built site to the `/ko/` path on the `gh-pages` branch using `mkdocs gh-deploy`.
    - Workflow triggers (`on.push.paths` and `on.pull_request.paths`) have been updated to include `mkdocs-ko.yml` and `docs-ko/**` to ensure the workflow runs when Korean documentation or its configuration is modified.

After this commit is merged and the GitHub Action completes, the Korean documentation should be available at `https://google-a2a.github.io/A2A/ko/`.

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/A2A/blob/main/CONTRIBUTING.md).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
