### PR TITLE
Fix: Correct identifier in Korean Python SDK docs

### DIFF
--- a/docs-ko/sdk/python/index.md
+++ b/docs-ko/sdk/python/index.md
@@ -6,7 +6,7 @@
 pip install a2a-sdk
 ```
 
-::: 호출
+::: a2a
     옵션:
         show_root_heading: false
         show_source: false


### PR DESCRIPTION
The mkdocs build for the Korean documentation (`mkdocs-ko.yml`) was failing with a `ModuleNotFoundError: No module named '호출'`.

This was caused by the `mkdocstrings` identifier `a2a` (referring to the Python package) being incorrectly translated to `호출` (Korean for "call" or "invocation") in `docs-ko/sdk/python/index.md`.

This commit changes `::: 호출` back to `::: a2a` in the aforementioned file, allowing `mkdocstrings` to find the correct Python package and resolving the build error.

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/A2A/blob/main/CONTRIBUTING.md).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
